### PR TITLE
fix vanilla learnset handling

### DIFF
--- a/tools/dump_narcs.py
+++ b/tools/dump_narcs.py
@@ -27,31 +27,31 @@ if __name__ == "__main__":
 		print("HG Engine Rom detected") 
 
 
-	with open('./dumped_armips/mondata.s', 'w') as file:
+	with open('./dumped_armips/mondata.s', 'w', encoding="utf-8") as file:
 		file.write(dump_mondata(mondata_narc))
 
 	# Dump Moves
 
 	moves_narc = dump_narc(rom, "a/0/1/1", MOVE_NARC_FORMAT)
-	with open('./dumped_armips/moves.s', 'w') as file:
+	with open('./dumped_armips/moves.s', 'w', encoding="utf-8") as file:
 		file.write(dump_moves(moves_narc))
 
 	# Dump Encounters
 
 	encounters_narc = dump_narc(rom, "a/0/3/7", ENCOUNTER_NARC_FORMAT)
-	with open('./dumped_armips/encounters.s', 'w') as file:
+	with open('./dumped_armips/encounters.s', 'w', encoding="utf-8") as file:
 		file.write(dump_encounters(encounters_narc, EXPANDED))
 
 	# Dump Evolutions
 
 	evodata_narc = dump_narc(rom, 'a/0/3/4', (EXPANDED_EVO_NARC_FORMAT if EXPANDED else EVO_NARC_FORMAT))
-	with open('./dumped_armips/evodata.s', 'w') as file:
+	with open('./dumped_armips/evodata.s', 'w', encoding="utf-8") as file:
 		file.write(dump_evodata(evodata_narc))
 
 	# Dump Learnsets
 
 	levelupdata_narc = dump_narc(rom, "a/0/3/3", (EXPANDED_LEARNSET_NARC_FORMAT if EXPANDED else LEARNSET_NARC_FORMAT))
-	with open('./dumped_armips/levelupdata.s', 'w') as file:
+	with open('./dumped_armips/levelupdata.s', 'w', encoding="utf-8") as file:
 		file.write(dump_levelupdata(levelupdata_narc))
 
 	# Dump Trainers

--- a/tools/dump_scripts/encounters.py
+++ b/tools/dump_scripts/encounters.py
@@ -15,63 +15,63 @@ def dump_encounters(narc, is_expanded):
 	for idx, enc in enumerate(narc):
 		encs_armip += f"{ENC_ENTRIES[idx]}\n"
 
-		encs_armip += f"walkrate {enc["walking_rate"]}\n"
-		encs_armip += f"surfrate {enc["surf_rate"]}\n"
-		encs_armip += f"rocksmashrate {enc["rock_smash_rate"]}\n"
-		encs_armip += f"oldrodrate {enc["old_rod_rate"]}\n"
-		encs_armip += f"goodrodrate {enc["good_rod_rate"]}\n"
-		encs_armip += f"superrodrate {enc["super_rod_rate"]}\n"
-		encs_armip += f"walklevels {", ".join(str(value) for key, value in enc.items() if key.startswith('walking_') and key.endswith('_level'))}\n\n"
+		encs_armip += f'walkrate {enc["walking_rate"]}\n'
+		encs_armip += f'surfrate {enc["surf_rate"]}\n'
+		encs_armip += f'rocksmashrate {enc["rock_smash_rate"]}\n'
+		encs_armip += f'oldrodrate {enc["old_rod_rate"]}\n'
+		encs_armip += f'goodrodrate {enc["good_rod_rate"]}\n'
+		encs_armip += f'superrodrate {enc["super_rod_rate"]}\n'
+		encs_armip += f"walklevels {', '.join(str(value) for key, value in enc.items() if key.startswith('walking_') and key.endswith('_level'))}\n\n"
 		
 		encs_armip += "// morning encounter slots\n"
 		for i in range(0,12):
-			encs_armip += f"{get_enc_macro(enc[f"morning_{i}_species_id"], "pokemon", is_expanded)}\n"
+			encs_armip += f'{get_enc_macro(enc[f"morning_{i}_species_id"], "pokemon", is_expanded)}\n'
 
 		encs_armip += "\n// day encounter slots\n"
 		for i in range(0,12):
-			encs_armip += f"{get_enc_macro(enc[f"day_{i}_species_id"], "pokemon", is_expanded)}\n"
+			encs_armip += f'{get_enc_macro(enc[f"day_{i}_species_id"], "pokemon", is_expanded)}\n'
 
 		encs_armip += "\n// night encounter slots\n"
 		for i in range(0,12):
-			encs_armip += f"{get_enc_macro(enc[f"night_{i}_species_id"], "pokemon", is_expanded)}\n"
+			encs_armip += f'{get_enc_macro(enc[f"night_{i}_species_id"], "pokemon", is_expanded)}\n'
 
 		encs_armip += "\n// hoenn encounter slots\n"
 		for i in range(0,2):
-			encs_armip += f"{get_enc_macro(enc[f"hoenn_{i}_species_id"], "pokemon", is_expanded)}\n"
+			encs_armip += f'{get_enc_macro(enc[f"hoenn_{i}_species_id"], "pokemon", is_expanded)}\n'
 
 		encs_armip += "\n// sinnoh encounter slots\n"
 		for i in range(0,2):
-			encs_armip += f"{get_enc_macro(enc[f"sinnoh_{i}_species_id"], "pokemon", is_expanded)}\n"
+			encs_armip += f'{get_enc_macro(enc[f"sinnoh_{i}_species_id"], "pokemon", is_expanded)}\n'
 
 		encs_armip += "\n// surf encounters\n"
 		for i in range(0,5):
-			encs_armip += f"{get_enc_macro(enc[f"surf_{i}_species_id"], "encounter", is_expanded )}, {enc[f"surf_{i}_min_lvl"]}, {enc[f"surf_{i}_max_lvl"]}\n"
+			encs_armip += f'{get_enc_macro(enc[f"surf_{i}_species_id"], "encounter", is_expanded )}, {enc[f"surf_{i}_min_lvl"]}, {enc[f"surf_{i}_max_lvl"]}\n'
 
 
 		encs_armip += "\n// rock smash encounters\n"
 		for i in range(0,2):
-			encs_armip += f"{get_enc_macro(enc[f"rock_smash_{i}_species_id"], "encounter", is_expanded )}, {enc[f"rock_smash_{i}_min_lvl"]}, {enc[f"rock_smash_{i}_max_lvl"]}\n"
+			encs_armip += f'{get_enc_macro(enc[f"rock_smash_{i}_species_id"], "encounter", is_expanded )}, {enc[f"rock_smash_{i}_min_lvl"]}, {enc[f"rock_smash_{i}_max_lvl"]}\n'
 
 		encs_armip += "\n// old rod encounters\n"
 		for i in range(0,5):
-			encs_armip += f"{get_enc_macro(enc[f"old_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"old_rod_{i}_min_lvl"]}, {enc[f"old_rod_{i}_max_lvl"]}\n"
+			encs_armip += f'{get_enc_macro(enc[f"old_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"old_rod_{i}_min_lvl"]}, {enc[f"old_rod_{i}_max_lvl"]}\n'
 
 		encs_armip += "\n// good rod encounters\n"
 		for i in range(0,5):
-			encs_armip += f"{get_enc_macro(enc[f"good_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"good_rod_{i}_min_lvl"]}, {enc[f"good_rod_{i}_max_lvl"]}\n"
+			encs_armip += f'{get_enc_macro(enc[f"good_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"good_rod_{i}_min_lvl"]}, {enc[f"good_rod_{i}_max_lvl"]}\n'
 
 		encs_armip += "\n// super rod encounters\n"
 		for i in range(0,5):
-			encs_armip += f"{get_enc_macro(enc[f"super_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"super_rod_{i}_min_lvl"]}, {enc[f"super_rod_{i}_max_lvl"]}\n"
+			encs_armip += f'{get_enc_macro(enc[f"super_rod_{i}_species_id"], "encounter", is_expanded )}, {enc[f"super_rod_{i}_min_lvl"]}, {enc[f"super_rod_{i}_max_lvl"]}\n'
 
 		encs_armip += "\n// swarm grass\n"
-		encs_armip += f"{get_enc_macro(enc[f"swarm_0_species_id"], "pokemon", is_expanded)}\n"
+		encs_armip += f'{get_enc_macro(enc[f"swarm_0_species_id"], "pokemon", is_expanded)}\n'
 		encs_armip += "// swarm surf\n"
-		encs_armip += f"{get_enc_macro(enc[f"swarm_1_species_id"], "pokemon", is_expanded)}\n"
+		encs_armip += f'{get_enc_macro(enc[f"swarm_1_species_id"], "pokemon", is_expanded)}\n'
 		encs_armip += "// swarm good rod\n"
-		encs_armip += f"{get_enc_macro(enc[f"swarm_2_species_id"], "pokemon", is_expanded)}\n"
+		encs_armip += f'{get_enc_macro(enc[f"swarm_2_species_id"], "pokemon", is_expanded)}\n'
 		encs_armip += "// swarm super rod\n"
-		encs_armip += f"{get_enc_macro(enc[f"swarm_3_species_id"], "pokemon", is_expanded)}\n\n"
+		encs_armip += f'{get_enc_macro(enc[f"swarm_3_species_id"], "pokemon", is_expanded)}\n\n'
 		encs_armip += ".close\n\n\n"
 
 	return encs_armip

--- a/tools/dump_scripts/evodata.py
+++ b/tools/dump_scripts/evodata.py
@@ -14,7 +14,7 @@ def dump_evodata(narc):
 	is_expanded = True if ("target_7" in narc[0]) else False
 
 	for idx, evo in enumerate(narc):
-		evodata_armip += f"evodata {MONS["SPECIES"][idx]}\n"
+		evodata_armip += f'evodata {MONS["SPECIES"][idx]}\n'
 
 		for i in range(0,9):
 			if f"target_{i}" in evo:
@@ -62,7 +62,7 @@ def get_evo_macro(species_id, method_id, param_id, is_expanded):
 		target = MONS["SPECIES"][base_form_id]
 		return f"    evolutionwithform {method}, {param}, {target}, {form_id}\n"
 	else:
-		return f"    evolution {method}, {param}, {MONS["SPECIES"][species_id]}\n"
+		return f"    evolution {method}, {param}, {MONS['SPECIES'][species_id]}\n"
 
 
 

--- a/tools/dump_scripts/levelupdata.py
+++ b/tools/dump_scripts/levelupdata.py
@@ -10,14 +10,14 @@ def dump_levelupdata(narc):
 	levelupdata_armip += "// the level up moves for each pokemon\n\n\n"
 
 	is_expanded = True if ("move_id_29" in narc[0]) else False
-	max_moves = 30 if is_expanded else 20
+	max_moves = 41 if is_expanded else 20
 
 	for idx, levelup in enumerate(narc):
-		levelupdata_armip += f"levelup {MONS["SPECIES"][idx]}\n"		
+		levelupdata_armip += f'levelup {MONS["SPECIES"][idx]}\n'
 		
 		for n in range(0,max_moves):
-			if levelup[f"move_id_{n}"] != 0xFFFF and levelup[f"move_id_{n}"] != 0:
-				levelupdata_armip += f"    learnset {MOVES["MOVE"][levelup[f"move_id_{n}"]]}, {levelup[f"lvl_learned_{n}"]}\n"
+			if levelup[f"move_id_{n}"] != 0xFFFF and levelup[f"move_id_{n}"] != 0 and levelup[f"lvl_learned_{n}"] <= 100:
+				levelupdata_armip += f'    learnset {MOVES["MOVE"][levelup[f"move_id_{n}"]]}, {levelup[f"lvl_learned_{n}"]}\n'
 			else:
 				levelupdata_armip += "    terminatelearnset\n\n\n"
 				break
@@ -25,12 +25,3 @@ def dump_levelupdata(narc):
 	levelupdata_armip += get_remaining_lines("../armips/data/levelupdata.s", len(narc), "levelup")
 
 	return levelupdata_armip
-
-
-
-
-
-
-
-
-

--- a/tools/dump_scripts/mondata.py
+++ b/tools/dump_scripts/mondata.py
@@ -26,11 +26,11 @@ def dump_mondata(narc):
 		
 		mondata_armip += f"{DEX_ENTRIES[idx][0]}"
 		mondata_armip += f'    basestats {mon["base_hp"]}, {mon["base_atk"]}, {mon["base_def"]}, {mon["base_speed"]}, {mon["base_spatk"]}, {mon["base_spdef"]}\n'
-		mondata_armip += f'    types {CONSTANTS['TYPE'][mon['type_1']]}, {CONSTANTS['TYPE'][mon['type_2']]}\n'
+		mondata_armip += f'    types {CONSTANTS["TYPE"][mon["type_1"]]}, {CONSTANTS["TYPE"][mon["type_2"]]}\n'
 		mondata_armip += f'    catchrate {mon["catchrate"]}\n'
 		mondata_armip += f'    baseexp 0 // defined in baseexp.s\n'
 		mondata_armip += f'    evyields {mon["hp_yield"]}, {mon["atk_yield"]}, {mon["def_yield"]}, {mon["speed_yield"]}, {mon["spatk_yield"]}, {mon["spdef_yield"]}\n'
-		mondata_armip += f'    items {ITEMS['ITEM'][mon['item_1']]}, {ITEMS['ITEM'][mon['item_2']]}\n'
+		mondata_armip += f'    items {ITEMS["ITEM"][mon["item_1"]]}, {ITEMS["ITEM"][mon["item_2"]]}\n'
 		mondata_armip += f'    genderratio {mon["gender"]}\n'
 		mondata_armip += f'    eggcycles {mon["hatch_cycle"]}\n'
 		mondata_armip += f'    basefriendship {mon["base_happy"]}\n'
@@ -47,7 +47,7 @@ def dump_mondata(narc):
 	return mondata_armip
 
 def get_mon_dex_entries(indexed_mons):
-	with open("../armips/data/mondata.s", 'r') as f:
+	with open("../armips/data/mondata.s", 'r', encoding="utf-8") as f:
 		content = f.readlines()
 
 	dex_entries = {}

--- a/tools/dump_scripts/moves.py
+++ b/tools/dump_scripts/moves.py
@@ -27,19 +27,19 @@ def dump_moves(narc):
 			break
 
 		moves_armip += f"{MOVE_ENTRIES[idx][0]}"
-		moves_armip += f"    battleeffect {MOVE_EFFECTS["MOVE"][move["effect"]]}\n"
-		moves_armip += f"    pss {MOVE_MACROS["SPLIT"][move["category"]]}\n"
-		moves_armip += f"    basepower {move["power"]}\n"
-		moves_armip += f"    type {CONSTANTS["TYPE"][move["type"]]}\n"
-		moves_armip += f"    accuracy {move["accuracy"]}\n"
-		moves_armip += f"    pp {move["pp"]}\n"
-		moves_armip += f"    effectchance {move["effect_chance"]}\n"
-		moves_armip += f"    target {MOVE_MACROS["MOVE"][move["target"]]}\n"
-		moves_armip += f"    priority {move["priority"]}\n"
-		moves_armip += f"    flags {get_flags(move["properties"])}\n"
-		moves_armip += f"    appeal 0x{move["appeal"]:02x}\n"
-		moves_armip += f"    contesttype {MOVE_MACROS["CONTEST"][move["contest_type"]]}\n"
-		moves_armip += f"    terminatedata\n"
+		moves_armip += f'    battleeffect {MOVE_EFFECTS["MOVE"][move["effect"]]}\n'
+		moves_armip += f'    pss {MOVE_MACROS["SPLIT"][move["category"]]}\n'
+		moves_armip += f'    basepower {move["power"]}\n'
+		moves_armip += f'    type {CONSTANTS["TYPE"][move["type"]]}\n'
+		moves_armip += f'    accuracy {move["accuracy"]}\n'
+		moves_armip += f'    pp {move["pp"]}\n'
+		moves_armip += f'    effectchance {move["effect_chance"]}\n'
+		moves_armip += f'    target {MOVE_MACROS["MOVE"][move["target"]]}\n'
+		moves_armip += f'    priority {move["priority"]}\n'
+		moves_armip += f'    flags {get_flags(move["properties"])}\n'
+		moves_armip += f'    appeal 0x{move["appeal"]:02x}\n'
+		moves_armip += f'    contesttype {MOVE_MACROS["CONTEST"][move["contest_type"]]}\n'
+		moves_armip += f'    terminatedata\n'
 		moves_armip += MOVE_ENTRIES[idx][1]
 		moves_armip += "\n"
 	moves_armip += get_remaining_lines("../armips/data/moves.s", len(narc), "movedata")


### PR DESCRIPTION
also fixes cp1252 text encoding and windows problems with getting it running on msys2
running python:
```
~/git/work/HG-Engine-Dumps/tools
$ python3
Python 3.11.9 (main, Apr 12 2024, 09:55:31)  [GCC 13.2.0 64 bit (AMD64)] on win32
```

<details>
<summary>relevant errors</summary>
<br>

fix for the first one is using different quotes inside of the f-string params than the ones used to contain the entire string
```
~/git/work/HG-Engine-Dumps/tools
$ python3 dump_narcs.py ../rom.nds
Traceback (most recent call last):
  File "C:/msys64/home/nwichers/git/work/HG-Engine-Dumps/tools/dump_narcs.py", line 8, in <module>
    from dump_scripts.mondata import dump_mondata
  File "C:/msys64/home/nwichers/git/work/HG-Engine-Dumps/tools/dump_scripts/mondata.py", line 29
    mondata_armip += f'    types {CONSTANTS['TYPE'][mon['type_1']]}, {CONSTANTS['TYPE'][mon['type_2'
]]}\n'
                                             ^^^^
SyntaxError: f-string: unmatched '['
```
python for windows for some reason assumes cp1252 ascii encoding for text, it was a bit of a headache a while ago in hg-engine main.  specifying utf-8 encoding should align everything properly across OS's
```
 ~/git/work/HG-Engine-Dumps/tools
$ python3 dump_narcs.py ../rom.nds
Traceback (most recent call last):
  File "C:/msys64/home/nwichers/git/work/HG-Engine-Dumps/tools/dump_narcs.py", line 31, in <module>
    file.write(dump_mondata(mondata_narc))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/nwichers/git/work/HG-Engine-Dumps/tools/dump_scripts/mondata.py", line 45, in
 dump_mondata
    mondata_armip += get_remaining_lines("../armips/data/mondata.s", len(narc), "mondata")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/nwichers/git/work/HG-Engine-Dumps/tools/dump_scripts/dump_tools.py", line 253
, in get_remaining_lines
    content = f.readlines()
              ^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.11/encodings/cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 937: character maps to <undef
ined>
```

</details>